### PR TITLE
add missing import

### DIFF
--- a/sercomm_common.py
+++ b/sercomm_common.py
@@ -1,5 +1,6 @@
 import hashlib
 import cStringIO
+import os
 
 def strip_nulls(str):
 	return str.strip('\x00')


### PR DESCRIPTION
traceback for this issue

```python
Traceback (most recent call last):
  File "../sercomm_fwutils/etoh.py", line 81, in <module>
    create_image()
  File "../sercomm_fwutils/etoh.py", line 68, in create_image
    hdr = create_hdr_from_info(blocks[0][2], len(payload))
  File "/root/stricted/sercomm_fwutils/sercomm_common.py", line 41, in create_hdr_from_info
    iv = os.urandom(32) # 32 random bytes, only the first 16 are used
NameError: global name 'os' is not defined
```