### PR TITLE
Switch to python3.

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -2,6 +2,7 @@ def nullpad_str(s, length):
     return s + ('\x00' * (length - len(s)))
 
 def unnullpad_str(s):
+    s = s.decode()
     if '\x00' not in s:
         return s
 


### PR DESCRIPTION
I attempted to move the code into python 3 I run under Linux Mint 21. I used a Sercomm H300s image to test it and I tested upon `decrypt_image.py` running like this:

```
python3 decrypt_image.py ../Vodafone_H_300s_v1.2.01.06_debug.img  ../img_decrypted.img
[+] Trying to interpret file as type1 image...
[-] File does not appear to be a valid type1 image, trying type2...
[-] Not a type2 image either, exiting
```

I am not sure if my changes actually work, any changes are done only to be able to run the code without any errors.
Would like some feedback or test images to compare.